### PR TITLE
fix: decouple extension rem size from host page

### DIFF
--- a/contents/floating-popup.tsx
+++ b/contents/floating-popup.tsx
@@ -118,7 +118,7 @@ const FloatingPopup = () => {
   }
 
   return (
-    <>
+    <div data-moe-copy-ai>
       {/* 浮动按钮 */}
       <div ref={refs.setReference} {...getReferenceProps()}>
         <FloatingButton onClick={handleButtonClick} isOpen={isOpen} />
@@ -147,7 +147,7 @@ const FloatingPopup = () => {
           </FloatingFocusManager>
         </>
       )}
-    </>
+    </div>
   )
 }
 

--- a/postcss-rem-to-var.js
+++ b/postcss-rem-to-var.js
@@ -1,0 +1,27 @@
+/**
+ * PostCSS 插件: 将 rem 单位转换为基于 CSS 变量的 calc() 表达式
+ */
+
+const remRE = /(-?[\d.]+)rem/g
+
+module.exports = (opts = {}) => {
+  const varName = opts.varName || "--moe-base-font-size"
+
+  return {
+    postcssPlugin: "postcss-rem-to-var",
+    Declaration(decl) {
+      if (remRE.test(decl.value)) {
+        decl.value = decl.value.replace(remRE, (match, num) => {
+          // 如果是 1rem,直接使用变量
+          if (num === "1") {
+            return `var(${varName})`
+          }
+          // 否则使用 calc()
+          return `calc(var(${varName}) * ${num})`
+        })
+      }
+    }
+  }
+}
+
+module.exports.postcss = true

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   plugins: {
     tailwindcss: {},
-    autoprefixer: {}
+    autoprefixer: {},
+    "./postcss-rem-to-var.js": {}
   }
 }

--- a/styles/global.css
+++ b/styles/global.css
@@ -2,6 +2,30 @@
 @tailwind components;
 @tailwind utilities;
 
+/* 插件根容器 - 定义独立的字体大小基准 */
+:root,
+#moe-copy-ai-root,
+[data-moe-copy-ai],
+.moe-copy-ai-container {
+  --moe-base-font-size: 16px;
+}
+
+/* 强制设置插件容器的字体大小基准,隔离宿主页面影响 */
+#moe-copy-ai-root,
+[data-moe-copy-ai],
+.moe-copy-ai-container {
+  font-size: var(--moe-base-font-size) !important;
+  line-height: 1.5;
+  box-sizing: border-box;
+}
+
+/* 确保所有子元素继承 box-sizing */
+#moe-copy-ai-root *,
+[data-moe-copy-ai] *,
+.moe-copy-ai-container * {
+  box-sizing: border-box;
+}
+
 @layer components {
   .top-bar {
     @apply backdrop-blur-sm backdrop-brightness-110 bg-elevated-1 rounded-2xl border border-line-1 shadow-lg;


### PR DESCRIPTION
resolve #30 

> [!WARNING]  
> 但其實還有一個離譜問題不知爲何就文心一言那邊body寬度受影響

<img width="3456" height="1924" alt="image" src="https://github.com/user-attachments/assets/f4ac282c-9647-432c-a5cc-406b8532d692" />
