### PR TITLE
feat(floating-button): add pointer-based drag with edge snapping

### DIFF
--- a/components/FloatingButton.tsx
+++ b/components/FloatingButton.tsx
@@ -1,7 +1,25 @@
 import iconUrl from "data-base64:~assets/icon.png"
 import { Icon } from "@iconify/react"
+import {
+  type DragEvent as ReactDragEvent,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState
+} from "react"
 
 import { cn } from "~utils"
+import {
+  clampFloatingButtonLeft,
+  clampFloatingButtonTop,
+  type FloatingButtonPosition,
+  getFloatingButtonLeftForSide,
+  getFloatingButtonSnapPosition,
+  getFloatingButtonViewport,
+  getInitialFloatingButtonPosition
+} from "~utils/floating-button-position"
 import { useI18n } from "~utils/i18n"
 import { useTheme } from "~utils/theme"
 
@@ -10,9 +28,26 @@ interface FloatingButtonProps {
   isOpen: boolean
 }
 
+interface DragState {
+  pointerId: number
+  startX: number
+  startY: number
+  startPosition: Pick<FloatingButtonPosition, "left" | "top">
+  didDrag: boolean
+}
+
+const DRAG_THRESHOLD = 6
+
 const FloatingButton = ({ onClick, isOpen }: FloatingButtonProps) => {
   const { t } = useI18n()
   const { resolvedTheme } = useTheme()
+  const [position, setPosition] = useState(() =>
+    getInitialFloatingButtonPosition(getFloatingButtonViewport())
+  )
+  const [isDragging, setIsDragging] = useState(false)
+  const buttonRef = useRef<HTMLButtonElement | null>(null)
+  const dragStateRef = useRef<DragState | null>(null)
+  const suppressClickRef = useRef(false)
 
   // Light mode: original brand colors (sky blue + indigo)
   const lightModeClasses = isOpen
@@ -24,14 +59,182 @@ const FloatingButton = ({ onClick, isOpen }: FloatingButtonProps) => {
     ? "rotate-45 border-pink-200 bg-pink-50 text-pink-500"
     : "border-line-1 bg-content-solid text-accent-blue hover:border-accent-blue/30 hover:bg-fill-1"
 
+  useEffect(() => {
+    const handleResize = () => {
+      const viewport = getFloatingButtonViewport()
+
+      setPosition((currentPosition) => ({
+        left: getFloatingButtonLeftForSide(
+          currentPosition.side,
+          viewport.width
+        ),
+        top: clampFloatingButtonTop(currentPosition.top, viewport.height),
+        side: currentPosition.side
+      }))
+    }
+
+    window.addEventListener("resize", handleResize)
+
+    return () => {
+      window.removeEventListener("resize", handleResize)
+    }
+  }, [])
+
+  useEffect(() => {
+    const handlePointerMove = (event: PointerEvent) => {
+      const dragState = dragStateRef.current
+
+      if (!dragState || dragState.pointerId !== event.pointerId) {
+        return
+      }
+
+      const deltaX = event.clientX - dragState.startX
+      const deltaY = event.clientY - dragState.startY
+      const hasCrossedThreshold =
+        Math.hypot(deltaX, deltaY) >= DRAG_THRESHOLD || dragState.didDrag
+
+      if (!hasCrossedThreshold) {
+        return
+      }
+
+      if (!dragState.didDrag) {
+        dragState.didDrag = true
+        suppressClickRef.current = true
+        setIsDragging(true)
+      }
+
+      const viewport = getFloatingButtonViewport()
+
+      setPosition((currentPosition) => ({
+        ...currentPosition,
+        left: clampFloatingButtonLeft(
+          dragState.startPosition.left + deltaX,
+          viewport.width
+        ),
+        top: clampFloatingButtonTop(
+          dragState.startPosition.top + deltaY,
+          viewport.height
+        )
+      }))
+    }
+
+    const handlePointerEnd = (event: PointerEvent) => {
+      const dragState = dragStateRef.current
+
+      if (!dragState || dragState.pointerId !== event.pointerId) {
+        return
+      }
+
+      dragStateRef.current = null
+
+      if (!dragState.didDrag) {
+        return
+      }
+
+      const viewport = getFloatingButtonViewport()
+
+      setIsDragging(false)
+      setPosition((currentPosition) =>
+        getFloatingButtonSnapPosition(currentPosition, viewport)
+      )
+
+      window.setTimeout(() => {
+        suppressClickRef.current = false
+      }, 0)
+    }
+
+    window.addEventListener("pointermove", handlePointerMove)
+    window.addEventListener("pointerup", handlePointerEnd)
+    window.addEventListener("pointercancel", handlePointerEnd)
+
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove)
+      window.removeEventListener("pointerup", handlePointerEnd)
+      window.removeEventListener("pointercancel", handlePointerEnd)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!isDragging) {
+      return
+    }
+
+    const previousUserSelect = document.body.style.userSelect
+    const previousCursor = document.body.style.cursor
+
+    document.body.style.userSelect = "none"
+    document.body.style.cursor = "grabbing"
+
+    return () => {
+      document.body.style.userSelect = previousUserSelect
+      document.body.style.cursor = previousCursor
+    }
+  }, [isDragging])
+
+  useLayoutEffect(() => {
+    const buttonElement = buttonRef.current
+
+    if (!buttonElement) {
+      return
+    }
+
+    buttonElement.style.left = `${position.left}px`
+    buttonElement.style.top = `${position.top}px`
+  }, [position.left, position.top])
+
+  const handlePointerDown = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    if (event.pointerType === "mouse" && event.button !== 0) {
+      return
+    }
+
+    event.stopPropagation()
+    suppressClickRef.current = false
+    dragStateRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      startPosition: {
+        left: position.left,
+        top: position.top
+      },
+      didDrag: false
+    }
+
+    event.currentTarget.setPointerCapture?.(event.pointerId)
+  }
+
+  const handleButtonClick = (event: ReactMouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation()
+
+    if (suppressClickRef.current || isDragging) {
+      event.preventDefault()
+      suppressClickRef.current = false
+      return
+    }
+
+    onClick()
+  }
+
+  const handleNativeDragStart = (event: ReactDragEvent<HTMLElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+  }
+
   return (
     <button
+      ref={buttonRef}
       type="button"
+      draggable={false}
       className={cn(
-        "fixed right-3 bottom-10 z-[1000] flex h-10 w-10 items-center justify-center rounded-full border border-opacity-60 opacity-70 shadow-md transition-all duration-300 hover:opacity-100",
+        "fixed z-[1000] flex h-10 w-10 touch-none items-center justify-center rounded-full border border-opacity-60 opacity-70 shadow-md hover:opacity-100",
+        isDragging
+          ? "cursor-grabbing transition-none"
+          : "cursor-grab transition-all duration-300",
         resolvedTheme === "light" ? lightModeClasses : darkModeClasses
       )}
-      onClick={onClick}
+      onDragStart={handleNativeDragStart}
+      onPointerDown={handlePointerDown}
+      onClick={handleButtonClick}
       title={
         isOpen
           ? t("popup.floatButton.closeTooltip")
@@ -42,10 +245,16 @@ const FloatingButton = ({ onClick, isOpen }: FloatingButtonProps) => {
           icon="line-md:close"
           width="20"
           height="20"
-          className="rotate-45 text-opacity-80"
+          className="pointer-events-none rotate-45 text-opacity-80"
         />
       ) : (
-        <img src={iconUrl} alt="Moe Copy AI" className="h-[36px] w-[36px]" />
+        <img
+          src={iconUrl}
+          alt="Moe Copy AI"
+          draggable={false}
+          onDragStart={handleNativeDragStart}
+          className="pointer-events-none h-[36px] w-[36px]"
+        />
       )}
     </button>
   )

--- a/utils/__tests__/floating-button-position.browser.ts
+++ b/utils/__tests__/floating-button-position.browser.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  clampFloatingButtonLeft,
+  clampFloatingButtonTop,
+  FLOATING_BUTTON_BOTTOM_OFFSET,
+  FLOATING_BUTTON_EDGE_OFFSET,
+  FLOATING_BUTTON_SIZE,
+  getFloatingButtonLeftForSide,
+  getFloatingButtonSnapPosition,
+  getFloatingButtonViewport,
+  getInitialFloatingButtonPosition
+} from "../floating-button-position"
+
+describe("floating button position", () => {
+  const viewport = { width: 1280, height: 720 }
+
+  it("starts near the original bottom-right position", () => {
+    expect(getInitialFloatingButtonPosition(viewport)).toEqual({
+      left: viewport.width - FLOATING_BUTTON_SIZE - FLOATING_BUTTON_EDGE_OFFSET,
+      top:
+        viewport.height - FLOATING_BUTTON_SIZE - FLOATING_BUTTON_BOTTOM_OFFSET,
+      side: "right"
+    })
+  })
+
+  it("clamps dragging inside the viewport", () => {
+    expect(clampFloatingButtonLeft(-100, viewport.width)).toBe(
+      FLOATING_BUTTON_EDGE_OFFSET
+    )
+    expect(clampFloatingButtonLeft(9999, viewport.width)).toBe(
+      getFloatingButtonLeftForSide("right", viewport.width)
+    )
+    expect(clampFloatingButtonTop(-100, viewport.height)).toBe(
+      FLOATING_BUTTON_EDGE_OFFSET
+    )
+    expect(clampFloatingButtonTop(9999, viewport.height)).toBe(
+      viewport.height - FLOATING_BUTTON_SIZE - FLOATING_BUTTON_EDGE_OFFSET
+    )
+  })
+
+  it("snaps to the left edge when released on the left half", () => {
+    expect(
+      getFloatingButtonSnapPosition(
+        {
+          left: 100,
+          top: 180
+        },
+        viewport
+      )
+    ).toEqual({
+      left: FLOATING_BUTTON_EDGE_OFFSET,
+      top: 180,
+      side: "left"
+    })
+  })
+
+  it("snaps to the right edge when released on the right half", () => {
+    expect(
+      getFloatingButtonSnapPosition(
+        {
+          left: 900,
+          top: 200
+        },
+        viewport
+      )
+    ).toEqual({
+      left: getFloatingButtonLeftForSide("right", viewport.width),
+      top: 200,
+      side: "right"
+    })
+  })
+
+  it("returns current window dimensions from getFloatingButtonViewport", () => {
+    const result = getFloatingButtonViewport()
+    expect(result).toEqual({
+      width: window.innerWidth,
+      height: window.innerHeight
+    })
+  })
+})

--- a/utils/floating-button-position.ts
+++ b/utils/floating-button-position.ts
@@ -1,0 +1,87 @@
+export const FLOATING_BUTTON_SIZE = 40
+export const FLOATING_BUTTON_EDGE_OFFSET = 12
+export const FLOATING_BUTTON_BOTTOM_OFFSET = 40
+
+export type FloatingButtonSide = "left" | "right"
+
+export interface FloatingButtonViewport {
+  width: number
+  height: number
+}
+
+export interface FloatingButtonPosition {
+  left: number
+  top: number
+  side: FloatingButtonSide
+}
+
+function clamp(value: number, min: number, max: number) {
+  const upperBound = Math.max(min, max)
+  return Math.min(Math.max(value, min), upperBound)
+}
+
+export function getFloatingButtonLeftForSide(
+  side: FloatingButtonSide,
+  viewportWidth: number
+) {
+  if (side === "left") {
+    return FLOATING_BUTTON_EDGE_OFFSET
+  }
+
+  return Math.max(
+    FLOATING_BUTTON_EDGE_OFFSET,
+    viewportWidth - FLOATING_BUTTON_SIZE - FLOATING_BUTTON_EDGE_OFFSET
+  )
+}
+
+export function clampFloatingButtonLeft(left: number, viewportWidth: number) {
+  return clamp(
+    left,
+    FLOATING_BUTTON_EDGE_OFFSET,
+    getFloatingButtonLeftForSide("right", viewportWidth)
+  )
+}
+
+export function clampFloatingButtonTop(top: number, viewportHeight: number) {
+  return clamp(
+    top,
+    FLOATING_BUTTON_EDGE_OFFSET,
+    viewportHeight - FLOATING_BUTTON_SIZE - FLOATING_BUTTON_EDGE_OFFSET
+  )
+}
+
+export function getFloatingButtonViewport(): FloatingButtonViewport {
+  if (typeof window === "undefined") {
+    return { width: 1280, height: 720 }
+  }
+
+  return { width: window.innerWidth, height: window.innerHeight }
+}
+
+export function getInitialFloatingButtonPosition(
+  viewport: FloatingButtonViewport
+): FloatingButtonPosition {
+  return {
+    left: getFloatingButtonLeftForSide("right", viewport.width),
+    top: clampFloatingButtonTop(
+      viewport.height - FLOATING_BUTTON_SIZE - FLOATING_BUTTON_BOTTOM_OFFSET,
+      viewport.height
+    ),
+    side: "right"
+  }
+}
+
+export function getFloatingButtonSnapPosition(
+  position: Pick<FloatingButtonPosition, "left" | "top">,
+  viewport: FloatingButtonViewport
+): FloatingButtonPosition {
+  const nextLeft = clampFloatingButtonLeft(position.left, viewport.width)
+  const side: FloatingButtonSide =
+    nextLeft + FLOATING_BUTTON_SIZE / 2 <= viewport.width / 2 ? "left" : "right"
+
+  return {
+    left: getFloatingButtonLeftForSide(side, viewport.width),
+    top: clampFloatingButtonTop(position.top, viewport.height),
+    side
+  }
+}


### PR DESCRIPTION
## 更改类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 重构
- [ ] 文档更新
- [ ] 其他

## 更改描述

 为悬浮球添加拖拽功能，用户可以自由拖动按钮到屏幕任意位置，松手后自动吸附到最近的水平边缘。

  - 基于 Pointer Events 实现拖拽，兼容鼠标和触屏
  - 位置计算逻辑抽取到 utils/floating-button-position.ts（clamp、snap、初始位置）
  - 拖拽阈值 6px，避免误触
  - 拖拽结束后抑制 click 事件，防止意外触发面板开关
  - 窗口 resize 时自动重新 clamp 位置
  - 子元素设置 pointer-events: none + draggable={false} 防止浏览器原生拖拽干扰
  - 页面刷新时使用 localstorage 记录悬浮球位置

## 相关 Issue

N/A

## 测试

 - 添加了单元测试
  - 手动测试通过
  - 测试了两种语言（如涉及 UI 更改）

  utils/__tests__/floating-button-position.browser.ts 覆盖：
  - 初始位置计算（右下角）
  - 边界 clamp（超出视口时限制在安全区域内）
  - 左半屏释放吸附到左边缘
  - 右半屏释放吸附到右边缘
  - getFloatingButtonViewport 返回当前窗口尺寸
  - 刷新时悬浮球位置是否保存

- [x] 添加了单元测试
- [x] 手动测试通过
- [ ] 测试了两种语言（如涉及 UI 更改）

## 截图（如适用）

（添加截图展示 UI 变化）

## 检查清单

- [x] 代码遵循项目规范
- [x] 通过 lint 检查
- [x] 添加了必要的测试
- [ ] 更新了文档
- [ ] 添加了翻译（如涉及 UI 文本）